### PR TITLE
Update package info and README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,9 @@
 
 `rce.js` is a TypeScript library that exposes a simple interface for controlling and monitoring **Rust Console Edition** servers hosted on **GPORTAL**. It wraps the official HTTP and WebSocket APIs so external tools can automate server administration and react to in‑game events.
 
+
+This repository is a personal fork of [b1nzeex/rce.js](https://github.com/b1nzeex/rce.js) for experiments and improvements according to my own criteria. All credit goes to the original project.
+
 ## Features
 
 - Login and token management via the GPORTAL authentication API.
@@ -19,7 +22,7 @@
 ## Installation
 
 ```bash
-npm i b1nzeex/rce.js
+npm i @ooovenenoso/rce.js
 ```
 
 ## Building from Source
@@ -34,7 +37,7 @@ The compiled files are written to the `dist` directory. Credentials may also be 
 ## Quick Example
 
 ```typescript
-import { RCEManager, RCEEvent, RCEIntent, LogLevel } from "rce.js";
+import { RCEManager, RCEEvent, RCEIntent, LogLevel } from "@ooovenenoso/rce.js";
 
 const rce = new RCEManager();
 await rce.init({ username: "", password: "" }, { level: LogLevel.Info });

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 `rce.js` is a TypeScript library that exposes a simple interface for controlling and monitoring **Rust Console Edition** servers hosted on **GPORTAL**. It wraps the official HTTP and WebSocket APIs so external tools can automate server administration and react to in‑game events.
 
+
+This repository is a personal fork of [b1nzeex/rce.js](https://github.com/b1nzeex/rce.js) for experiments and improvements according to my own criteria. All credit goes to the original project.
+
 ## Features
 
 - Login and token management via the GPORTAL authentication API.
@@ -19,7 +22,7 @@
 ## Installation
 
 ```bash
-npm i b1nzeex/rce.js
+npm i @ooovenenoso/rce.js
 ```
 
 ## Building from Source
@@ -34,7 +37,7 @@ The compiled files are written to the `dist` directory. Credentials may also be 
 ## Quick Example
 
 ```typescript
-import { RCEManager, RCEEvent, RCEIntent, LogLevel } from "rce.js";
+import { RCEManager, RCEEvent, RCEIntent, LogLevel } from "@ooovenenoso/rce.js";
 
 const rce = new RCEManager();
 await rce.init({ username: "", password: "" }, { level: LogLevel.Info });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rce.js",
-  "version": "3.6.0",
+  "name": "@ooovenenoso/rce.js",
+  "version": "3.6.1",
   "main": "dist/index.js",
   "directories": {
     "test": "tests"
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/b1nzeex/rce.js.git"
+    "url": "https://github.com/ooovenenoso/rce.js.git"
   },
   "keywords": [
     "rce",


### PR DESCRIPTION
## Summary
- rename package to `@ooovenenoso/rce.js` and update repository URL
- bump version to 3.6.1
- document that this fork is for personal experiments and credit the upstream project
- update install and import instructions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68456c9d7e88832cad93d223c6e717ea